### PR TITLE
Fixes broken links in articles_intro.html

### DIFF
--- a/articles_intro.html
+++ b/articles_intro.html
@@ -179,7 +179,7 @@ $(".main-container").removeClass("main-container").removeClass("container-fluid"
 
 <p>Interactive documents are a new way to build Shiny apps. An interactive document is an <a href="http://rmarkdown.rstudio.com">R Markdown</a> file that contains Shiny widgets and outputs. You write the report in <a href="http://daringfireball.net/projects/markdown/basics">markdown</a>, and then launch it as an app with the click of a button.</p>
 <p>This article will show you how to write an R Markdown report.</p>
-<p>The companion article, <a href="interactive-docs.html">Introduction to interactive documents</a>, will show you how to turn an R Markdown report into an interactive document with Shiny components.</p>
+<p>The companion article, <a href="http://shiny.rstudio.com/articles/interactive-docs.html">Introduction to interactive documents</a>, will show you how to turn an R Markdown report into an interactive document with Shiny components.</p>
 <div id="r-markdown" class="section level2">
 <h2>R Markdown</h2>
 <p>R Markdown is a file format for making dynamic documents with R. An R Markdown document is written in markdown (an easy-to-write plain text format) and contains chunks of embedded R code, like the document below.</p>
@@ -218,7 +218,7 @@ Note that the `echo = FALSE` parameter was added to the code chunk to prevent pr
 <img src="articles/images/rmd-temp.png" />
 
 </div>
-<p>In practice, you do not need to call <code>rmarkdown::render()</code>. You can use a button in the RStudio IDE to render your reprt. R Markdown is heavily <a href="../articles/rmd-integration.html">integrated into the RStudio IDE</a>.</p>
+<p>In practice, you do not need to call <code>rmarkdown::render()</code>. You can use a button in the RStudio IDE to render your reprt. R Markdown is heavily <a href="http://shiny.rstudio.com/articles/rmd-integration.html">integrated into the RStudio IDE</a>.</p>
 </div>
 <div id="getting-started" class="section level2">
 <h2>Getting started</h2>
@@ -386,7 +386,7 @@ Some inline R code, 4.
 <p>You can update your document at any time by re-knitting the code chunks.</p>
 <p>You can then convert your document into several common formats.</p>
 <p>R Markdown documents implement Donald’s Knuth’s idea of literate programming and take the manual labor out of writing and maintaining reports. Moreover, they are quick to learn. You already know ecnough about markdown, knitr, and YAML to begin writing your own R Markdown reports.</p>
-<p>In the next article, <a href="interactive-docs.html">Introduction to interactive documents</a>, you will learn how to add interactive Shiny components to an R Markdown report. This creates a quick workflow for writing light-weight Shiny apps.</p>
+<p>In the next article, <a href="http://shiny.rstudio.com/articles/interactive-docs.html">Introduction to interactive documents</a>, you will learn how to add interactive Shiny components to an R Markdown report. This creates a quick workflow for writing light-weight Shiny apps.</p>
 <p>To learn more about R Markdown and interactive documents, please visit <a href="http://rmarkdown.rstudio.com">rmarkdown.rstudio.com</a>.</p>
 </div>
 


### PR DESCRIPTION
Fixes relative links that were written when articles_intro appeared at the shiny dev center.